### PR TITLE
Tweak build to pull in all necessary deps:

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -15,7 +15,4 @@ fn main() {
     cfg.include(&dep_dir);
 
     cfg.compile("libpngshim.a");
-
-    println!("cargo:rustc-link-search=native={}", env::var("OUT_DIR").unwrap());
-    println!("cargo:rustc-link-lib=static=pngshim");
 }

--- a/png-sys/Cargo.toml
+++ b/png-sys/Cargo.toml
@@ -10,3 +10,6 @@ build = "build.rs"
 [lib]
 name = "png_sys"
 path = "lib.rs"
+
+[dependencies]
+libz-sys = "0.1"

--- a/png-sys/build.rs
+++ b/png-sys/build.rs
@@ -52,7 +52,7 @@ fn main() {
 
     println!("cargo:root={}", dst.display());
     println!("cargo:rustc-link-search=native={}/.libs", dst.display());
-    println!("cargo:rustc-link-lib=png16");
+    println!("cargo:rustc-link-lib=static=png16");
 }
 
 fn run(cmd: &mut Command) {

--- a/png-sys/lib.rs
+++ b/png-sys/lib.rs
@@ -1,1 +1,1 @@
-// Intentionally blank
+extern crate libz_sys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@
 #![cfg_attr(feature="serde-serialization", plugin(serde_macros))]
 
 extern crate libc;
+extern crate png_sys;
 
 #[cfg(feature="serde-serialization")]
 extern crate serde;


### PR DESCRIPTION
- Don't print link directives when using `extern crate gcc`, it already does
  this by default
- Link png16 statically (as before)
- Link to png_sys to ensure that all the deps are pulled in
